### PR TITLE
docs: adds missing "bottomOffset" example on setBreakpoints method

### DIFF
--- a/docs/public-methods.md
+++ b/docs/public-methods.md
@@ -101,8 +101,8 @@ myPane.backdrop({show: false}); // hide
 ```
 
 ## setBreakpoints
-### setBreakpoints(breakpoints: **PaneBreaks**)
-Method updates breakpoints configuration for rendered Pane
+### setBreakpoints(breakpoints: **PaneBreaks**, bottomOffset?: number)
+Method updates breakpoints configuration and bottomOffset for rendered Pane
 ```javascript
 myPane.setBreakpoints({
   top: {
@@ -113,6 +113,12 @@ myPane.setBreakpoints({
   middle: { ... },
   bottom: { ... }
 });
+
+myPane.setBreakpoints({
+  top: { ... },
+  middle: { ... },
+  bottom: { ... }
+}, 100 );
 ```
 
 ## preventDismiss


### PR DESCRIPTION
I discovered the bottomOffset parameter through TypeScript typings and it was exactly what I needed, so I'm adding this for others to discover more easily.